### PR TITLE
Make docs less confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Dredd is an HTTP API testing tool. You can find out more about it at [its docume
 
 ## How to run Dredd using Docker?
 
-You can use following to run `dredd` without any arguments:
+Following line runs the `dredd` command using the `apiaryio/dredd` Docker image:
 
 ```shell
-docker run -it -v $PWD:/api -w /api apiaryio/dredd
+docker run -it -v $PWD:/api -w /api apiaryio/dredd dredd
 ```
 
-When you need to pass arguments, append the whole command you want to run. For example, if you want to run `dredd init`, run following instead:
+As an example of how to pass arguments, following line runs the `dredd init` command:
 
 ```shell
 docker run -it -v $PWD:/api -w /api apiaryio/dredd dredd init


### PR DESCRIPTION
People who do not live their lives in Docker are not aware of the default command functionality. People who are aware of it can easily find it and use it if they want. Ignoring the functionality makes the docs clearer and more straightforward.